### PR TITLE
Update runner.sh

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -60,6 +60,9 @@ for ENV in "${ENVS[@]}"; do
         REGISTER_PARAMS=${REGISTER_PARAMS}' --env '${ENV}
 done
 
+# unregister all previous runners
+gitlab-runner unregister --all-runners
+
 # register runner
 yes '' | gitlab-runner register ${REGISTER_PARAMS}
 


### PR DESCRIPTION
Lors du redémarrage du container via portainer par exemple, le script runner.sh se relance. Cela a pour effet de créer un nouveau runner sans supprimer le précédent.

Je propose donc de `unregister` les runners dans le script avant de `register` le nouveau.